### PR TITLE
feat: add wayland support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["bevy", "ratatui", "terminal", "tui", "aquarium"]
 include = ["/src", "/assets"]
 
 [dependencies]
-bevy = "0.14.0"
+bevy = { version = "0.14.0", features = ["wayland"] }
 bevy_atmosphere = "0.10.0"
 bevy_hanabi = "0.12.0"
 bevy_ratatui = "0.6.1"


### PR DESCRIPTION
This enables the `wayland` feature to support Wayland environments. I think this would require generating a new `Cargo.lock`.

Btw, I loved your project!