### PR TITLE
Add nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1730272153,
+        "narHash": "sha256-B5WRZYsRlJgwVHIV6DvidFN7VX7Fg9uuwkRW9Ha8z+w=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "2d2a9ddbe3f2c00747398f3dc9b05f7f2ebb0f53",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,8 @@
             nativeBuildInputs = with pkgs; [
               pkg-config
             ];
+
+            # https://github.com/bevyengine/bevy/blob/main/docs/linux_dependencies.md#nix
             buildInputs = with pkgs; [
               udev
               alsa-lib

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,40 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixpkgs-unstable";
+    flake-utils = {
+      url = "github:numtide/flake-utils";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        packages = rec {
+          lifecycler = pkgs.rustPlatform.buildRustPackage {
+            name = "lifecycler";
+            src = pkgs.lib.cleanSource ./.;
+
+            cargoLock = {
+              lockFile = ./Cargo.lock;
+              outputHashes = {
+                "zune-jpeg-0.4.11" = "sha256-Iks3Gslg+LcGIWQL2K3SfGTKxamlYv8SiRfq14kW/pE=";
+              };
+            };
+
+            nativeBuildInputs = with pkgs; [
+              pkg-config
+            ];
+            buildInputs = with pkgs; [
+              alsa-lib
+              udev
+            ];
+          };
+
+          default = lifecycler;
+        };
+      });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
       in
       {
         packages = rec {
-          lifecycler = pkgs.rustPlatform.buildRustPackage {
+          lifecycler = pkgs.rustPlatform.buildRustPackage rec {
             name = "lifecycler";
             src = pkgs.lib.cleanSource ./.;
 
@@ -29,9 +29,17 @@
               pkg-config
             ];
             buildInputs = with pkgs; [
-              alsa-lib
               udev
+              alsa-lib
+              vulkan-loader
+              xorg.libX11
+              xorg.libXcursor
+              xorg.libXi
+              xorg.libXrandr
+              libxkbcommon
+              wayland
             ];
+            LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath buildInputs;
           };
 
           default = lifecycler;


### PR DESCRIPTION
I just wanted to try out this project and noticed there was no nix flake available.
So I quickly coded one.
This will allow users of the Nix package manager to just download, build and run this project with all dependencies in one command.

`$ nix run github:jla2000/lifecycler/add-nix-flake`